### PR TITLE
Avoid reformat_transcript() on original pinyin

### DIFF
--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -48,6 +48,68 @@ class FormatPinyin(Base):
         reformat_transcript(note, 'pinyin', 'pinyin')
         self.assertEqual(note['Pinyin'], expected)
 
+    def test_fill_transcript_pinyin_empty(self):
+        hanzi = '可能'
+        note = {'Hanzi': hanzi, 'Pinyin': ''}
+        # TODO: The '<!-- ken eng -->' is incorrecly split because it relies
+        #       on regexp splitting of keneng instead of using the two <span>
+        #       containers as a source-of-truth.
+        expected = (
+            '<span class="tone3">kě</span>'
+            '<span class="tone2">néng</span> '
+            '<!-- ken eng -->'
+        )
+        fill_transcript(hanzi, note)
+        self.assertEqual(note['Pinyin'], expected)
+        fill_transcript(hanzi, note) # Verify stability with a second attempt
+        self.assertEqual(note['Pinyin'], expected)
+
+    def test_fill_transcript_pinyin_unchanged(self):
+        hanzi = '可能'
+        # The contents of `pinyin_html` is taken from fill_transcript('可能').
+        # See the testcase `test_fill_transcript_pinyin_empty` above.
+        pinyin_html = (
+            '<span class="tone3">kě</span>'
+            '<span class="tone2">néng</span> '
+            '<!-- ken eng -->'
+        )
+        note = {'Hanzi': hanzi, 'Pinyin': pinyin_html}
+        fill_transcript(hanzi, note)
+        self.assertEqual(note['Pinyin'], pinyin_html)
+        fill_transcript(hanzi, note) # Verify stability with a second attempt
+        self.assertEqual(note['Pinyin'], pinyin_html)
+
+    def test_fill_transcript_pinyin_changed(self):
+        # The word 大都 has two translations:
+        #   dàdōu: "for the most part"
+        #   dàdū: "metropolis"
+        # The extension will initially give the user the pinyin "dàdū".
+        # If the user changes it to "dàdōu", the extension should split it into
+        # "dà dōu" without reverting it to the initial "dàdū" transcription.
+        hanzi = '大都'
+        note = {'Hanzi': hanzi, 'Pinyin': ''}
+        expected_initial = (
+            '<span class="tone4">dà</span>'
+            '<span class="tone1">dū</span> '
+            '<!-- da du -->'
+        )
+        fill_transcript(hanzi, note)
+        self.assertEqual(note['Pinyin'], expected_initial)
+        fill_transcript(hanzi, note) # Verify stability with a second attempt
+        self.assertEqual(note['Pinyin'], expected_initial)
+
+        # User changes the pinyin to "da4dou1"
+        note['Pinyin'] = 'da4dou1'
+        expected_final = (
+            '<span class="tone4">dà</span>'
+            '<span class="tone1">dōu</span> '
+            '<!-- da dou -->'
+        )
+        fill_transcript(hanzi, note)
+        self.assertEqual(note['Pinyin'], expected_final)
+        fill_transcript(hanzi, note) # Verify stability with a second attempt
+        self.assertEqual(note['Pinyin'], expected_final)
+
 
 class FillSound(Base):
     def test_missing_sound(self):

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -35,6 +35,7 @@ from tests import Base
 
 
 class FormatPinyin(Base):
+    # https://github.com/luoliyan/chinese-support-redux/issues/78
     def test_issue_78(self):
         note = {'Hanzi': '壮观', 'Pinyin': 'zhuàngguān'}
         expected = (


### PR DESCRIPTION
Pulling fixes from https://github.com/Jacobinski

> Before this change, there are two different ways that the code interacts with
> `pinyin` in a note:
> 
>   1. If the `pinyin` field is empty, it uses the `hanzi` field as a
>      source-of-truth to generate the `pinyin` field.
> 
>   2. If the `pinyin` field is non-empty, it takes the contents of
>      `pinyin` and runs `reformat_transcript()` on it. The idea of this
>      function is that it will update (split, colorize, etc) the `pinyin`
>      field with new information (that the user provides). This function
>      does the splitting using a regular-expression.
> 
> We have observed a bug in this logic that occurs for some words, such as
> 可能 which initially see the correct pinyin populated ("kě néng") but
> have this pinyin incorrectly change ("kěn éng") as a result of running
> the `reformat_transcript()` function on them. This bug can occur for any
> pinyin in which there are multiple acceptable regular expression splits.
> 
> Bug report: https://github.com/Gustaf-C/anki-chinese-support-3/issues/55
> 
> This commit attempts to put a bandaid over the issue by avoiding repopulating
> the pinyin field for words if the user did not change the original hanzi
> transcription. Unit tests and documentation are also included in the commit.